### PR TITLE
Improvements for cocoapods projects

### DIFF
--- a/LocalizationEditor/Providers/LocalizationProvider.swift
+++ b/LocalizationEditor/Providers/LocalizationProvider.swift
@@ -11,7 +11,7 @@ import Files
 import Foundation
 
 class LocalizationProvider {
-    private let ignoredDirectories = ["Carthage", "build", ".framework"]
+    private let ignoredDirectories = ["Pods", "Carthage", "build", ".framework"]
     
     func getLocalizations(url: URL) -> [LocalizationGroup] {
         Log.debug?.message("Searching \(url) for Localizable.strings")


### PR DESCRIPTION
Adding 'pods' directory to list of ignored directory names in order to provide functionality with cocoapod-controlled projects.