### PR TITLE
Faster and more robust single line comments handling

### DIFF
--- a/sources/LocalizationEditor/Providers/Parser.swift
+++ b/sources/LocalizationEditor/Providers/Parser.swift
@@ -51,6 +51,18 @@ class Parser {
         try results = interpretTokens()
         return results
     }
+
+    private func skipSingleLineComments() {
+        while !input.isEmpty, let character = String(input[input.startIndex]).unicodeScalars.first, CharacterSet.whitespacesAndNewlines.contains(character) {
+            input.remove(at: input.index(input.startIndex, offsetBy: 0))
+        }
+
+        if input.hasPrefix("//"), let endIndex = input.index(of: "\n") {
+            let rangeForRemoving = input.startIndex ..< endIndex
+            input.removeSubrange(rangeForRemoving)
+        }
+    }
+
     /**
      This function reads through the input and populates an array of tokens.
      
@@ -63,6 +75,8 @@ class Parser {
             // Actions depend on the current state.
             switch state {
             case .other:
+                skipSingleLineComments()
+
                 // Extract the upcoming control character, also switch the current state and append the extracted token, if any.
                 if let extractedToken = try prepareNextState() {
                     tokens.append(extractedToken)

--- a/sources/LocalizationEditor/Providers/Parser.swift
+++ b/sources/LocalizationEditor/Providers/Parser.swift
@@ -52,12 +52,18 @@ class Parser {
         return results
     }
 
-    private func skipSingleLineComments() {
+    /**
+     Special handling for single line comments to turn them into message tokens. Should only be called when state is other so // in a middle of value does not get caught
+     */
+    private func skipAndProcessSingleLineComments() {
         while !input.isEmpty, let character = String(input[input.startIndex]).unicodeScalars.first, CharacterSet.whitespacesAndNewlines.contains(character) {
             input.remove(at: input.index(input.startIndex, offsetBy: 0))
         }
 
         if input.hasPrefix("//"), let endIndex = input.index(of: "\n") {
+            let messageRange = input.index(input.startIndex, offsetBy: 2) ..< endIndex
+            tokens.append(.message(String(input[messageRange])))
+
             let rangeForRemoving = input.startIndex ..< endIndex
             input.removeSubrange(rangeForRemoving)
         }
@@ -75,7 +81,7 @@ class Parser {
             // Actions depend on the current state.
             switch state {
             case .other:
-                skipSingleLineComments()
+                skipAndProcessSingleLineComments()
 
                 // Extract the upcoming control character, also switch the current state and append the extracted token, if any.
                 if let extractedToken = try prepareNextState() {

--- a/sources/LocalizationEditor/Providers/ParserTypes.swift
+++ b/sources/LocalizationEditor/Providers/ParserTypes.swift
@@ -39,14 +39,19 @@ protocol SeperatingType: ControlCharacterType {}
 /// - messageBoundaryClose Ends a message.
 /// - quote Wraps a key or a value.
 enum EnclosingControlCharacters: String, EnclosingType, CaseIterable {
-    case messageBoundaryOpenSingleline = "//"
-    case messageBoundaryCloseSingleline = "\r"
-    case messageBoundaryOpenMultiline = "/*"
-    case messageBoundaryCloseMultiline = "*/"
+    case messageBoundaryOpen = "/*"
+    case messageBoundaryClose = "*/"
     case quote = "\""
 
     var skippingLength: Int {
-        return self.rawValue.count
+        switch self {
+        case .messageBoundaryOpen:
+            return EnclosingControlCharacters.messageBoundaryOpen.rawValue.count
+        case .messageBoundaryClose:
+            return EnclosingControlCharacters.messageBoundaryClose.rawValue.count
+        case .quote:
+            return EnclosingControlCharacters.quote.rawValue.count
+        }
     }
 }
 

--- a/sources/LocalizationEditorTests/Data/LocalizableStrings-en-with-complete-messages.strings
+++ b/sources/LocalizationEditorTests/Data/LocalizableStrings-en-with-complete-messages.strings
@@ -27,7 +27,7 @@
 /* Commenting Message for Author's blog */
 "blog" = "Author's blog";
 
-/* Commenting Message */
+// Commenting Message with "quotes"
 "done" = "Done";
 
 /* Commenting Message for Feed */


### PR DESCRIPTION
Reverts #41 because the solution was very slow, does the same in a more efficient and robust way