### PR TITLE
Comments at the end of line are treated as messages and integrated single line comments

### DIFF
--- a/sources/LocalizationEditor/Info.plist
+++ b/sources/LocalizationEditor/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>2.1</string>
 	<key>CFBundleVersion</key>
-	<string>191</string>
+	<string>198</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/sources/LocalizationEditor/Providers/Parser.swift
+++ b/sources/LocalizationEditor/Providers/Parser.swift
@@ -54,23 +54,6 @@ class Parser {
     }
 
     /**
-     Special handling for single line comments to turn them into message tokens. Should only be called when state is other so // in a middle of value does not get caught
-     */
-    private func skipAndProcessSingleLineComments() {
-        while !input.isEmpty, let character = String(input[input.startIndex]).unicodeScalars.first, CharacterSet.whitespacesAndNewlines.contains(character) {
-            input.remove(at: input.index(input.startIndex, offsetBy: 0))
-        }
-
-        if input.hasPrefix("//"), let endIndex = input.index(of: "\n") {
-            let messageRange = input.index(input.startIndex, offsetBy: 2) ..< endIndex
-            tokens.append(.message(String(input[messageRange])))
-
-            let rangeForRemoving = input.startIndex ..< endIndex
-            input.removeSubrange(rangeForRemoving)
-        }
-    }
-
-    /**
      This function reads through the input and populates an array of tokens.
      
      Implemented using a state machine. The state machine depends on ```ParserState```. When in .other, the next control character is used to determine the next state. When reading a key/value/message, upcoming text is interpreted as key/value/message until the corresponding closing control character is found.
@@ -82,8 +65,6 @@ class Parser {
             // Actions depend on the current state.
             switch state {
             case .other:
-//                skipAndProcessSingleLineComments()
-
                 // Extract the upcoming control character, also switch the current state and append the extracted token, if any.
                 if let extractedToken = try prepareNextState() {
                     tokens.append(extractedToken)
@@ -182,7 +163,7 @@ class Parser {
         }
         return results
     }
-    /// Determines the token that ends an entry. An entry can either be ended by a semicolon (if no comment was provided or the comment is above the entry) or a comment located at the end of a line. In the second case the `.newline` token marks the end of the entry.
+    /// Determines the token that ends an entry. An entry can either be ended by a semicolon (if no comment was provided or the comment is above the entry) or a comment located at the end of a line. In the second case the `.message` token marks the end of the entry.
     ///
     /// - Parameter tokens: The tokens that were extracted during tokenization.
     /// - Returns: The token that ends an entry.

--- a/sources/LocalizationEditor/Providers/ParserTypes.swift
+++ b/sources/LocalizationEditor/Providers/ParserTypes.swift
@@ -28,11 +28,11 @@ enum Token {
     /// - Returns: `true` when the type of `other` matches the type of `self` without taking associated values into account.
     func isCaseEqual(to other: Token) -> Bool {
         switch (self, other) {
-        case (.message(_), .message(_)):
+        case (.message, .message):
             return true
-        case (.value(_), .value(_)):
+        case (.value, .value):
             return true
-        case (.key(_), .key(_)):
+        case (.key, .key):
             return true
         case (.equal, .equal):
             return true
@@ -65,6 +65,8 @@ enum EnclosingControlCharacters: String, EnclosingType, CaseIterable {
     case messageBoundaryOpen = "/*"
     case messageBoundaryClose = "*/"
     case quote = "\""
+    case singleLineMessageOpen = "//"
+    case singleLineMessageClose = "\n"
 
     var skippingLength: Int {
         switch self {
@@ -74,6 +76,10 @@ enum EnclosingControlCharacters: String, EnclosingType, CaseIterable {
             return EnclosingControlCharacters.messageBoundaryClose.rawValue.count
         case .quote:
             return EnclosingControlCharacters.quote.rawValue.count
+        case .singleLineMessageOpen:
+            return EnclosingControlCharacters.singleLineMessageOpen.rawValue.count
+        case .singleLineMessageClose:
+            return EnclosingControlCharacters.singleLineMessageClose.rawValue.count
         }
     }
 }

--- a/sources/LocalizationEditor/Providers/ParserTypes.swift
+++ b/sources/LocalizationEditor/Providers/ParserTypes.swift
@@ -21,6 +21,29 @@ enum Token {
     case key(String)
     case equal
     case semicolon
+    case newline
+    /// Checks if `self` is of the same type as `other` without taking the associated values into account.
+    ///
+    /// - Parameter other: The token to which self should be compared to.
+    /// - Returns: `true` when the type of `other` matches the type of `self` without taking associated values into account.
+    func isCaseEqual(to other: Token) -> Bool {
+        switch (self, other) {
+        case (.message(_), .message(_)):
+            return true
+        case (.value(_), .value(_)):
+            return true
+        case (.key(_), .key(_)):
+            return true
+        case (.equal, .equal):
+            return true
+        case (.semicolon, .semicolon):
+            return true
+        case (.newline, .newline):
+            return true
+        default:
+            return false
+        }
+    }
 }
 
 /// Control characters define starting and end points of tokens. They can be for example ", /* or ;
@@ -65,11 +88,14 @@ enum SeperatingControlCharacters: String, SeperatingType, CaseIterable {
             return SeperatingControlCharacters.equal.rawValue.count
         case .semicolon:
             return SeperatingControlCharacters.semicolon.rawValue.count
+        case .newline:
+            return SeperatingControlCharacters.newline.rawValue.count
         }
     }
 
     case equal = "="
     case semicolon = ";"
+    case newline = "\n"
 }
 
 /// Errors that may occure during parsing.

--- a/sources/LocalizationEditor/Providers/ParserTypes.swift
+++ b/sources/LocalizationEditor/Providers/ParserTypes.swift
@@ -15,6 +15,7 @@ import Foundation
 /// - key: The key and its text.
 /// - equal: The equal sign that maps a key to a value: ".
 /// - semicolon: The semicolon that ends a line: ;
+/// - newline: A new line \n.
 enum Token {
     case message(String)
     case value(String)
@@ -58,9 +59,11 @@ protocol EnclosingType: ControlCharacterType {}
 protocol SeperatingType: ControlCharacterType {}
 
 /// Enclosing control characters that wrapp text. They may start or end a message or contain a value/key.
-/// - messageBoundaryOpen Opens a message.
-/// - messageBoundaryClose Ends a message.
-/// - quote Wraps a key or a value.
+/// - messageBoundaryOpen: Opens a message.
+/// - messageBoundaryClose: Ends a message.
+/// - quote: Wraps a key or a value.
+/// - singleLineMessageOpen: Opens a single line message.
+/// - singleLineMessageClose: Closes the single line message.
 enum EnclosingControlCharacters: String, EnclosingType, CaseIterable {
     case messageBoundaryOpen = "/*"
     case messageBoundaryClose = "*/"
@@ -85,8 +88,9 @@ enum EnclosingControlCharacters: String, EnclosingType, CaseIterable {
 }
 
 /// Seperating control characters do not wrap text. They function as position markers. For example they seperate a key from its value or end the line.
-/// - equal The equal sign that seperates a key from its value.
-/// - semicolon The semicolon that end a line.
+/// - equal: The equal sign that seperates a key from its value.
+/// - semicolon: The semicolon that end a line.
+/// - newline: A new line.
 enum SeperatingControlCharacters: String, SeperatingType, CaseIterable {
     var skippingLength: Int {
         switch self {

--- a/sources/LocalizationEditorTests/ParserIsolationTests.swift
+++ b/sources/LocalizationEditorTests/ParserIsolationTests.swift
@@ -90,6 +90,32 @@ class LocalizationEditor: XCTestCase {
         XCTAssertEqual(result[2].message, "Select your birhtday")
     }
 
+    func testInputValidWithSinglelineMessageTrailing() {
+        let inputString =
+        """
+"Start %@" = "Empieza a %@"; // e.g., "Start bouldering", "Start Top Range"
+
+"BACK" = "Zurück"; // String for "back operation"
+
+"BIRTHDAY_SELECT" = "Bitte wähle deinen Geburtstag aus"; // Select your birhtday
+"""
+        let parser = Parser(input: inputString)
+        let result = try! parser.parse()
+        
+        XCTAssertEqual(result.count, 3)
+        XCTAssertEqual(result[0].key, "Start %@")
+        XCTAssertEqual(result[1].key, "BACK")
+        XCTAssertEqual(result[2].key, "BIRTHDAY_SELECT")
+        
+        XCTAssertEqual(result[0].value, "Empieza a %@")
+        XCTAssertEqual(result[1].value, "Zurück")
+        XCTAssertEqual(result[2].value, "Bitte wähle deinen Geburtstag aus")
+        
+        XCTAssertEqual(result[0].message, "e.g., \"Start bouldering\", \"Start Top Range\"")
+        XCTAssertEqual(result[1].message, "String for \"back operation\"")
+        XCTAssertEqual(result[2].message, "Select your birhtday")
+    }
+    
     func testInputValidWithSinglelineMessage() {
         let inputString =
         """
@@ -191,34 +217,31 @@ garbage garbage...
     
     func testInputValidWithTrailingMessage() {
         let inputString =
-        """
-//
-//  ParserIsolationTests.swift
-//  LocalizationEditor
-//
-//  Created by Andreas Neusüß on 30.12.18.
-//  Copyright © 2018 Igor Kulman. All rights reserved.
-//
+ """
+ //
+ //  ParserIsolationTests.swift
+ //  LocalizationEditor
+ //
+ //  Created by Andreas Neusüß on 30.12.18.
+ //  Copyright © 2018 Igor Kulman. All rights reserved.
+ //
+ 
+ "ART_"AND"_CUL\nTURE" = "Kunst "und" Kultur"; /* The string for "the art and culture category */
+ 
+ "BACK" = "Zurück"; /* String for back operation */
+ 
+ "BIRTHDAY_SELECT" = "Bitte wähle deinen Geburtstag aus"; /* Select your birhtday */
+ """
 
-"ART_"AND"_CUL
-
-TURE" = "Kunst "und"
-
-Kultur"; /* The string for "the art and culture category */
-
-"BACK" = "Zurück"; /* String for back operation */
-
-"BIRTHDAY_SELECT" = "Bitte wähle deinen Geburtstag aus"; /* Select your birhtday */
-"""
         let parser = Parser(input: inputString)
         let result = try! parser.parse()
         
         XCTAssertEqual(result.count, 3)
-        XCTAssertEqual(result[0].key, "ART_\"AND\"_CUL\n\nTURE")
+        XCTAssertEqual(result[0].key, "ART_\"AND\"_CUL\nTURE")
         XCTAssertEqual(result[1].key, "BACK")
         XCTAssertEqual(result[2].key, "BIRTHDAY_SELECT")
         
-        XCTAssertEqual(result[0].value, "Kunst \"und\"\n\nKultur")
+        XCTAssertEqual(result[0].value, "Kunst \"und\" Kultur")
         XCTAssertEqual(result[1].value, "Zurück")
         XCTAssertEqual(result[2].value, "Bitte wähle deinen Geburtstag aus")
         

--- a/sources/LocalizationEditorTests/ParserIsolationTests.swift
+++ b/sources/LocalizationEditorTests/ParserIsolationTests.swift
@@ -189,6 +189,44 @@ garbage garbage...
         XCTAssertEqual(result[2].message, "Select your birhtday")
     }
     
+    func testInputValidWithTrailingMessage() {
+        let inputString =
+        """
+//
+//  ParserIsolationTests.swift
+//  LocalizationEditor
+//
+//  Created by Andreas Neusüß on 30.12.18.
+//  Copyright © 2018 Igor Kulman. All rights reserved.
+//
+
+"ART_"AND"_CUL
+
+TURE" = "Kunst "und"
+
+Kultur"; /* The string for "the art and culture category */
+
+"BACK" = "Zurück"; /* String for back operation */
+
+"BIRTHDAY_SELECT" = "Bitte wähle deinen Geburtstag aus"; /* Select your birhtday */
+"""
+        let parser = Parser(input: inputString)
+        let result = try! parser.parse()
+        
+        XCTAssertEqual(result.count, 3)
+        XCTAssertEqual(result[0].key, "ART_\"AND\"_CUL\n\nTURE")
+        XCTAssertEqual(result[1].key, "BACK")
+        XCTAssertEqual(result[2].key, "BIRTHDAY_SELECT")
+        
+        XCTAssertEqual(result[0].value, "Kunst \"und\"\n\nKultur")
+        XCTAssertEqual(result[1].value, "Zurück")
+        XCTAssertEqual(result[2].value, "Bitte wähle deinen Geburtstag aus")
+        
+        XCTAssertEqual(result[0].message, "The string for \"the art and culture category")
+        XCTAssertEqual(result[1].message, "String for back operation")
+        XCTAssertEqual(result[2].message, "Select your birhtday")
+    }
+    
     func testMalformattedInput() {
         let inputString1 =
         """


### PR DESCRIPTION
I took a look at #52 and adapted the parser. Now it's able to parse comments that are placed at the end of a line. 

With this Pull Request I also removed the workaround of interpreting a leading "//" as a single line comment and integrated that feature as well.

Test cover the new case where a trailing message ends an entry.