### PR TITLE
Fixed KeyCell labels so they can wrap long strings.

### DIFF
--- a/sources/LocalizationEditor/UI/Cells/KeyCell.xib
+++ b/sources/LocalizationEditor/UI/Cells/KeyCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15702" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15702"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -13,24 +13,24 @@
             <rect key="frame" x="0.0" y="0.0" width="480" height="43"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5X2-ia-2YA">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="500" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="5X2-ia-2YA">
                     <rect key="frame" x="-2" y="21" width="484" height="17"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="17" id="7vH-UA-4O8"/>
+                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="17" id="7vH-UA-4O8"/>
                     </constraints>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Key" id="DsA-f5-s8p">
-                        <font key="font" metaFont="titleBar"/>
+                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Key" id="DsA-f5-s8p">
+                        <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wQA-SD-Muk">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="500" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="wQA-SD-Muk">
                     <rect key="frame" x="-2" y="5" width="484" height="14"/>
                     <constraints>
                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="t5Q-r1-Qz7"/>
                     </constraints>
-                    <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" title="Message" id="3fR-Cn-IJU">
-                        <font key="font" metaFont="toolTip"/>
+                    <textFieldCell key="cell" selectable="YES" title="Message" id="3fR-Cn-IJU">
+                        <font key="font" metaFont="label" size="11"/>
                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>


### PR DESCRIPTION
The KeyCell labels had wrong content compression priorities. This lead to UI issues with long strings in the message or the key. The cells will no autoresize their height along with the labels to fit the strings.

This should fix #39.