### PR TITLE
Handle escaping of the control character

### DIFF
--- a/sources/LocalizationEditorTests/Data/Special.strings
+++ b/sources/LocalizationEditorTests/Data/Special.strings
@@ -6,4 +6,7 @@
   Copyright © 2019 Igor Kulman. All rights reserved.
 */
 
-"quoted" = "some \"quoted\" message";
+/* The presence of a non-quoted string and a quoted string would previously cause the quoted string to be dropped. This string is here to check for regressions in quoted string parsing. */
+"regression_test" = "DO NOT DELETE";
+
+"quoted" = "\"http://\" or \"https://\"";

--- a/sources/LocalizationEditorTests/LocalizationProviderParsingTests.swift
+++ b/sources/LocalizationEditorTests/LocalizationProviderParsingTests.swift
@@ -74,6 +74,6 @@ class LocalizationProviderParsingTests: XCTestCase {
         let provider = LocalizationProvider()
         let groups = provider.getLocalizations(url: createTestingDirectory(with: [TestFile(originalFileName: "Special.strings", destinationFileName: "LocalizableStrings.strings", destinationFolder: "Base.lproj")]))
 
-        XCTAssertEqual(groups[0].localizations[0].translations.first(where: {$0.key == "quoted"})?.value, "some \"quoted\" message")
+        XCTAssertEqual(groups[0].localizations[0].translations.first(where: {$0.key == "quoted"})?.value, "\"http://\" or \"https://\"")
     }
 }


### PR DESCRIPTION
I've added the ability to handle an escape character when the control is a single `Character` in length. 

I've also added a value to `Special.strings` to make sure that the parser won't fall back to interpreting the file as an `NSDictionary`. This tests for a case where previously the parser would complete successfully, but drop the quoted value. A value such as `\"http://\" or \"https://\"` would be parsed as `[.key("quoted"), .equal, .value("\\"), .message("\\\" or \\\"https://\\\"\";")]` due to the parser encountering a `//` and attempting to read a comment. Since values don't get added to the results until a semicolon is encountered, it would cause the quoted string to be dropped.