### PR TITLE
Fix installation instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ When you change any of the translations the corresponding `Localizable.strings` 
 ### Homebrew
 
 ```bash
-brew cask install localizationeditor
+brew install --cask localizationeditor
 ```
 
 ### Manual


### PR DESCRIPTION
Fix error when installing using latest Homebrew. This is not a bug of this app, but readme needs to be fixed.

screenshot:

![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103323117-afc51780-4a84-11eb-9c05-bb00625e58c1.png)
