### PR TITLE
Use correct emoji flags for ZH-HK and ZH-Hant

### DIFF
--- a/sources/LocalizationEditor/Models/Flag.swift
+++ b/sources/LocalizationEditor/Models/Flag.swift
@@ -25,8 +25,14 @@ struct Flag {
 
     private var emojiFlag: String? {
         // special cases for zh-Hant and zh-Hans
-        if languageCode.hasPrefix("ZH-") && languageCode.count == 7 {
-            return "🇨🇳"
+        if languageCode.hasPrefix("ZH-") {
+            if languageCode.hasSuffix("HK") {
+                return "🇭🇰"
+            } else if languageCode.hasSuffix("TW") || languageCode.uppercased().hasSuffix("HANT") {
+                return "🇹🇼"
+            } else {
+                return "🇨🇳"
+            }
         }
 
         guard languageCode.count == 2 || (languageCode.count == 5 && languageCode.contains("-")) else {


### PR DESCRIPTION
Currently, all `zh-*` locales use the Chinese flag emoji by default. This commit adds support for more specific locales under `zh-`, such as `zh-HK` and `zh-Hant`.