### PR TITLE
Use correct emoji flag for KO

### DIFF
--- a/sources/LocalizationEditor/Models/Flag.swift
+++ b/sources/LocalizationEditor/Models/Flag.swift
@@ -113,6 +113,8 @@ struct Flag {
             return "🇮🇱"
         case "AR":
             return "🇱🇧"
+        case "KO":
+            return "🇰🇷"
         default:
             return emojiFlag(countryCode: language)
         }


### PR DESCRIPTION
Add the emoji flag 🇰🇷 for KO(Korean).