### PR TITLE
Update for Xcode 13.

### DIFF
--- a/sources/.swiftlint.yml
+++ b/sources/.swiftlint.yml
@@ -9,7 +9,7 @@ disabled_rules:
 
 analyzer_rules:
     - unused_import
-    - unused_private_declaration
+    - unused_declaration
 
 number_separator:
     minimum_length: 7

--- a/sources/LocalizationEditor.xcodeproj/project.pbxproj
+++ b/sources/LocalizationEditor.xcodeproj/project.pbxproj
@@ -351,7 +351,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1010;
-				LastUpgradeCheck = 1110;
+				LastUpgradeCheck = 1310;
 				ORGANIZATIONNAME = "Igor Kulman";
 				TargetAttributes = {
 					F3D9C94120BEC7460081830A = {
@@ -441,7 +441,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\n\nif which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 		F3EF22082209F25F000E8C80 /* Build number */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -565,6 +565,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -625,6 +626,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;

--- a/sources/LocalizationEditor.xcodeproj/xcshareddata/xcschemes/LocalizationEditor.xcscheme
+++ b/sources/LocalizationEditor.xcodeproj/xcshareddata/xcschemes/LocalizationEditor.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1110"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
This PR:
1. Update to recommended settings for Xcode 13. (Setting `CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER` to `YES`)
2. Ensures SwiftLint installed from Homebrew on M1 Macs runs properly, see: [SwiftLint #3378](https://github.com/realm/SwiftLint/pull/3778)
3. SwiftLint's analyzer rule `unused_private_declaration` has been renamed to `unused_declaration` in `0.34.0`, see [here](https://github.com/realm/SwiftLint/releases/tag/0.34.0)